### PR TITLE
GoPhish HTML Template for Message Clipped

### DIFF
--- a/MessageClipped.html
+++ b/MessageClipped.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+	<title></title>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+<p>...</p>
+
+<table width="100%">
+</table>
+
+<p>[Message Clipped] <a href="{{.URL}}">View entire message</a></p>
+</body>
+</html>


### PR DESCRIPTION
This is a very simple template used by malicious actors in 2019. I think this is a great pre-text for any remote/mobile users as they may have seen this if the contents cannot be displayed on their e-mail. 

Example:

https://blogs.k-state.edu/scams/2019/05/13/phishing-scam-05-13-19-message-clipped-view-entire-message/